### PR TITLE
Hide GQL introspection

### DIFF
--- a/app/graphql/countryfier_schema.rb
+++ b/app/graphql/countryfier_schema.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CountryfierSchema < GraphQL::Schema
+  disable_introspection_entry_points if Rails.env.production?
+
   query(Types::QueryType)
   mutation(Types::MutationType)
 end


### PR DESCRIPTION
Hide GQL introspection in production.
https://graphql-ruby.org/schema/introspection#disabling-introspection